### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+gdown==5.2.0
+gradio==5.4.0
+ipython==8.12.3
+matplotlib==3.9.2
+numpy==2.1.2
+Pillow==11.0.0
+protobuf==5.28.3
+pytesseract==0.3.13
+Requests==2.32.3
+tensorflow==2.18.0
+tensorflow_text>=1.0.0
+tqdm==4.66.6


### PR DESCRIPTION
To make it easier for contributors, it's helpful to include a requirements.txt file. This way, they can avoid manually installing the necessary dependencies.